### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# xProlog
-![build status](https://travis-ci.org/exercism/xprolog.svg?branch=master)
+# Exercism Prolog Track
+![build status](https://travis-ci.org/exercism/prolog.svg?branch=master)
 
 Exercism Exercises in Prolog
 
 ## Setup
 
-See [INSTALLATION.md](https://github.com/exercism/xprolog/blob/master/docs/INSTALLATION.md)
+See [INSTALLATION.md](https://github.com/exercism/prolog/blob/master/docs/INSTALLATION.md)
 
 ##Contributing
 
@@ -66,10 +66,10 @@ test(hello_world_with_a_name, condition(pending)) :-
     hello_world('Alice', 'Hello Alice!').
 ```
 
-All the tests for xProlog exercises can be run from the top level of the repo
+All the tests for Exercism Prolog Track exercises can be run from the top level of the repo
 with `bin/build.sh`. Please run this command before submitting your PR.
 
 
-### [SWI Prolog icon](https://github.com/exercism/xprolog/tree/master/img/icon.png)
+### [SWI Prolog icon](https://github.com/exercism/prolog/tree/master/img/icon.png)
 
-The SWI Prolog "Owlie" logo is owned by the SWI Prolog maintainers and released under the Simplified BSD license. We have adapted it for use on Exercism, changing the colour scheme, with [the express permission of `anne@swiprolog.org`](https://github.com/exercism/xprolog/issues/1#issuecomment-283122027).
+The SWI Prolog "Owlie" logo is owned by the SWI Prolog maintainers and released under the Simplified BSD license. We have adapted it for use on Exercism, changing the colour scheme, with [the express permission of `anne@swiprolog.org`](https://github.com/exercism/prolog/issues/1#issuecomment-283122027).

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "prolog",
   "language": "Prolog",
-  "repository": "https://github.com/exercism/xprolog",
+  "repository": "https://github.com/exercism/prolog",
   "active": false,
   "exercises": [
     {


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1