### PR TITLE
Remove redundant key/value pairs from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,5 @@
 {
-  "slug": "prolog",
   "language": "Prolog",
-  "repository": "https://github.com/exercism/prolog",
   "active": false,
   "exercises": [
     {


### PR DESCRIPTION
The slug is not used anywhere. We initialize a track based on knowing the Track ID.
Since the repository is always named after the track ID, this field, too, is redundant,
as it can be inferred.


See https://github.com/exercism/meta/issues/19