### PR TITLE
Add default 'Hello, World!' snippet

### DIFF
--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,0 +1,6 @@
+hello(Name, Greeting) :-
+  atom_concat('Hello, ', Name, Prefix),
+  atom_concat(Prefix, '!', Greeting).
+
+?- hello('World', Greeting),
+   write(Greeting).


### PR DESCRIPTION
Hi @kytrinyx! As [requested](https://github.com/exercism/prolog/pull/48) I've taken a stab at a 'Hello, World!' snippet - this one comes in at 39 characters wide, hopefully with still-explanatory variable names (but let me know if they're not clear).

Unlike most snippets I could see for other languages I've included an example of how the `hello/2` predicate would be called and the result used, since it felt like this would otherwise be obscure to someone completely new to Prolog. Does that seem sensible?

Related:
* https://github.com/exercism/meta/issues/89
* https://github.com/exercism/prolog/pull/48