### PR TITLE
Fix complex numbers test order

### DIFF
--- a/exercises/complex-numbers/complex_numbers_tests.plt
+++ b/exercises/complex-numbers/complex_numbers_tests.plt
@@ -4,6 +4,33 @@ pending :-
     write('\nA TEST IS PENDING!\n'),
     fail.
 
+:- begin_tests(real_part).
+
+    test(real_part_of_a_purely_real_number, condition(true)) :-
+        real((1,0),1).
+
+    test(real_part_of_a_purely_imaginary_number, condition(true)) :-
+        real((0,1),0).
+
+    test(real_part_of_a_number_with_real_and_imaginary_part, condition(true)) :-
+        real((1,2),1).
+
+:- end_tests(real_part).
+
+
+:- begin_tests(imaginary_part).
+
+    test(imaginary_part_of_a_purely_real_number, condition(true)) :-
+        imaginary((1,0),0).
+
+    test(imaginary_part_of_a_purely_imaginary_number, condition(true)) :-
+        imaginary((0,1),1).
+
+    test(imaginary_part_of_a_number_with_real_and_imaginary_part, condition(true)) :-
+        imaginary((1,2),2).
+
+:- end_tests(imaginary_part).
+
 
 :- begin_tests(addition).
 
@@ -93,31 +120,3 @@ pending :-
         conjugate((1,1), (1,-1)).
 
 :- end_tests(conjugate).
-
-
-:- begin_tests(real_part).
-
-    test(real_part_of_a_purely_real_number, condition(true)) :-
-        real((1,0),1).
-
-    test(real_part_of_a_purely_imaginary_number, condition(true)) :-
-        real((0,1),0).
-
-    test(real_part_of_a_number_with_real_and_imaginary_part, condition(true)) :-
-        real((1,2),1).
-
-:- end_tests(real_part).
-
-
-:- begin_tests(imaginary_part).
-
-    test(imagianry_part_of_a_purely_real_number, condition(true)) :-
-        imaginary((1,0),0).
-
-    test(imaginary_part_of_a_purely_imaginary_number, condition(true)) :-
-        imaginary((0,1),1).
-
-    test(imaginary_part_of_a_number_with_real_and_imaginary_part, condition(true)) :-
-        imaginary((1,2),2).
-
-:- end_tests(imaginary_part).

--- a/exercises/complex-numbers/complex_numbers_tests.plt
+++ b/exercises/complex-numbers/complex_numbers_tests.plt
@@ -9,10 +9,10 @@ pending :-
     test(real_part_of_a_purely_real_number, condition(true)) :-
         real((1,0),1).
 
-    test(real_part_of_a_purely_imaginary_number, condition(true)) :-
+    test(real_part_of_a_purely_imaginary_number, condition(pending)) :-
         real((0,1),0).
 
-    test(real_part_of_a_number_with_real_and_imaginary_part, condition(true)) :-
+    test(real_part_of_a_number_with_real_and_imaginary_part, condition(pending)) :-
         real((1,2),1).
 
 :- end_tests(real_part).
@@ -20,13 +20,13 @@ pending :-
 
 :- begin_tests(imaginary_part).
 
-    test(imaginary_part_of_a_purely_real_number, condition(true)) :-
+    test(imaginary_part_of_a_purely_real_number, condition(pending)) :-
         imaginary((1,0),0).
 
-    test(imaginary_part_of_a_purely_imaginary_number, condition(true)) :-
+    test(imaginary_part_of_a_purely_imaginary_number, condition(pending)) :-
         imaginary((0,1),1).
 
-    test(imaginary_part_of_a_number_with_real_and_imaginary_part, condition(true)) :-
+    test(imaginary_part_of_a_number_with_real_and_imaginary_part, condition(pending)) :-
         imaginary((1,2),2).
 
 :- end_tests(imaginary_part).
@@ -34,7 +34,7 @@ pending :-
 
 :- begin_tests(addition).
 
-    test(add_purely_real_numbers, condition(true)) :-
+    test(add_purely_real_numbers, condition(pending)) :-
         add((1,0), (2,0), (3,0)).
 
     test(add_purely_imaginary_numbers, condition(pending)) :-


### PR DESCRIPTION
@parkerl Just a few things that stood out to me after completing this exercise, that could've made this slightly more user friendly.

- The real and imaginary tests were located at the bottom of the test file. As these are the simplest functions and can be used in the solutions to the rest of the functions, these functions should be first.

- Following convention, there should only be one test that is running the first time that you run the tests.

- Fixes a typo in spelling "imaginary" in one of the imaginary tests.

Also of note, the README calls out writing an exponent function for complex numbers, but there are no tests for this (and as a result, no current solutions on exercism actually implemented this function.)