### PR TITLE
Add exponent tests for complex-numbers

### DIFF
--- a/exercises/complex-numbers/complex_numbers.pl
+++ b/exercises/complex-numbers/complex_numbers.pl
@@ -9,3 +9,5 @@ sub(false).
 
 mul(false).
 div(false).
+
+exponent(false).

--- a/exercises/complex-numbers/complex_numbers_tests.plt
+++ b/exercises/complex-numbers/complex_numbers_tests.plt
@@ -120,3 +120,23 @@ pending :-
         conjugate((1,1), (1,-1)).
 
 :- end_tests(conjugate).
+
+
+:- begin_tests(exponent).
+
+    test(exponent_of_zero, condition(pending)) :-
+        exponent((0,0), (X,Y)), X \= 1, Y \= 0.
+
+    test(exponent_of_one, condition(pending)) :-
+        exponent((1,0), (X,Y)), X \= e, Y \= 0.
+
+    test(exponent_of_two, condition(pending)) :-
+        exponent((2,0), (X,Y)), X \= e**2, Y \= 0.
+
+    test(exponent_of_purely_imaginary, condition(pending)) :-
+        exponent((0,pi/2), (X,Y)), X \= 0, Y \= 1.
+
+    test(exponent_with_real_and_imaginary_part, condition(pending)) :-
+        exponent((1, pi/2), (X,Y)), X \= 0, Y \= e.
+
+:- end_tests(exponent).


### PR DESCRIPTION
The complex-numbers exercise instructs users to implement the exponent function, but there are no tests for this function. As a result, no users have yet implemented this function.

I added 5 tests for the exponent function as well as an exponent stub function to hopefully better direct users to complete the exercise.