### PR TITLE
Add auto_approve to hello-world exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
       "slug": "hello-world",
       "uuid": "68a85ec5-acdd-4f4f-9b9e-a5e39f1f7ac0",
       "core": false,
+      "auto_approve": true,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": []


### PR DESCRIPTION
This adds the auto_approve property to the hello-world 
exercise as part of preparing tracks for the v2 launch.

The current code on the server will automatically approve
hello-world exercises anyway, but that is a temporary fix
and will be removed in the future.

See exercism/prolog#66