### PR TITLE
Override GitHub language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# file extention for Prolog Test files confuses GitHub linguist
+# explicitly set language for .plt extention
+*.plt linguist-language=Prolog


### PR DESCRIPTION
The Prolog test files (extention .plt) are detected as GnuPlot. I have added a .gitattributes file to override linguist.

You can see the language stats working on my fork.

https://github.com/github/linguist#using-gitattributes
