### PR TITLE
improvement on complex-numbers tests

### DIFF
--- a/exercises/complex-numbers/complex_numbers_tests.plt
+++ b/exercises/complex-numbers/complex_numbers_tests.plt
@@ -7,13 +7,13 @@ pending :-
 :- begin_tests(real_part).
 
     test(real_part_of_a_purely_real_number, condition(true)) :-
-        real((1,0),1).
+        real((1,0),R), R =:= 1.
 
     test(real_part_of_a_purely_imaginary_number, condition(pending)) :-
-        real((0,1),0).
+        real((0,1),R), R =:= 0.
 
     test(real_part_of_a_number_with_real_and_imaginary_part, condition(pending)) :-
-        real((1,2),1).
+        real((1,2),R), R =:= 1.
 
 :- end_tests(real_part).
 
@@ -21,13 +21,13 @@ pending :-
 :- begin_tests(imaginary_part).
 
     test(imaginary_part_of_a_purely_real_number, condition(pending)) :-
-        imaginary((1,0),0).
+        imaginary((1,0),R), R =:= 0.
 
     test(imaginary_part_of_a_purely_imaginary_number, condition(pending)) :-
-        imaginary((0,1),1).
+        imaginary((0,1),R), R =:= 1.
 
     test(imaginary_part_of_a_number_with_real_and_imaginary_part, condition(pending)) :-
-        imaginary((1,2),2).
+        imaginary((1,2),R), R =:= 2.
 
 :- end_tests(imaginary_part).
 
@@ -35,13 +35,13 @@ pending :-
 :- begin_tests(addition).
 
     test(add_purely_real_numbers, condition(pending)) :-
-        add((1,0), (2,0), (3,0)).
+        add((1,0), (2,0), (X,Y)), X =:= 3, Y =:= 0.
 
     test(add_purely_imaginary_numbers, condition(pending)) :-
-        add((0,1), (0,2), (0,3)).
+        add((0,1), (0,2), (X,Y)), X =:= 0, Y =:= 3.
 
     test(add_numbers_with_real_and_imaginary_part, condition(pending)) :-
-        add((1,2), (3,4), (4,6)).
+        add((1,2), (3,4), (X,Y)), X =:= 4, Y =:= 6.
 
 :- end_tests(addition).
 
@@ -49,13 +49,13 @@ pending :-
 :- begin_tests(subtraction).
 
     test(subtract_purely_real_numbers, condition(pending)) :-
-        sub((1,0), (2,0), (-1,0)).
+        sub((1,0), (2,0), (X,Y)), X =:= -1, Y =:= 0.
 
     test(subtract_purely_imaginary_numbers, condition(pending)) :-
-        sub((0,1), (0,2), (0,-1)).
+        sub((0,1), (0,2), (X,Y)), X =:= 0, Y =:= -1.
 
     test(subtract_numbers_with_real_and_imaginary_part, condition(pending)) :-
-        sub((1,2), (3,4), (-2,-2)).
+        sub((1,2), (3,4), (X,Y)), X =:= -2, Y =:= -2.
 
 :- end_tests(subtraction).
 
@@ -63,13 +63,13 @@ pending :-
 :- begin_tests(multiplication).
 
     test(multiply_purely_real_numbers, condition(pending)) :-
-        mul((1,0), (2,0), (2,0)).
+        mul((1,0), (2,0), (X,Y)), X =:= 2, Y =:= 0.
 
     test(multiply_purely_imaginary_numbers, condition(pending)) :-
-        mul((0,1), (0,2), (-2,0)).
+        mul((0,1), (0,2), (X,Y)), X =:= -2, Y =:= 0.
 
     test(multiply_numbers_with_real_and_imaginary_part, condition(pending)) :-
-        mul((1,2), (3,4), (-5, 10)).
+        mul((1,2), (3,4), (X,Y)), X =:= -5, Y =:= 10.
 
 :- end_tests(multiplication).
 
@@ -77,13 +77,13 @@ pending :-
 :- begin_tests(division).
 
     test(divide_purely_real_numbers, condition(pending)) :-
-        div((1,0), (2,0), (0.5,0)).
+        div((1,0), (2,0), (X,Y)), X =:= 0.5, Y =:= 0.
 
     test(divide_purely_imaginary_numbers, condition(pending)) :-
-        div((0,1), (0,2), (0.5,0)).
+        div((0,1), (0,2), (X,Y)), X =:= 0.5, Y =:= 0.
 
     test(divide_numbers_with_real_and_imaginary_part, condition(pending)) :-
-        div((1,2), (3,4), (0.44, 0.08)).
+        div((1,2), (3,4), (X,Y)), X =:= 0.44, Y =:= 0.08.
 
 :- end_tests(division).
 
@@ -105,18 +105,21 @@ pending :-
     test(absolute_value_of_a_number_with_real_and_imaginary_part, condition(pending)) :-
         abs((3,4), R), R =:= 5.
 
+    test(absolute_value_of_larger_number_with_real_and_imaginary_part, condition(pending)) :- 
+        abs((68, 285), R), R =:= 293.
+
 :- end_tests(absolute_value).
 
 
 :- begin_tests(conjugate).
 
     test(conjugate_a_purely_real_number, condition(pending)) :-
-        conjugate((5,0), (5,0)).
+        conjugate((5,0), (X,Y)), X =:= 5, Y =:= 0.
 
     test(conjugate_a_purely_imaginary_number, condition(pending)) :-
-        conjugate((0,5), (0,-5)).
+        conjugate((0,5), (X,Y)), X =:= 0, Y =:= -5 .
 
     test(conjugate_a_number_with_real_and_imaginary_part, condition(pending)) :-
-        conjugate((1,1), (1,-1)).
+        conjugate((1,1), (X,Y)), X =:= 1, Y =:= -1.
 
 :- end_tests(conjugate).


### PR DESCRIPTION
While mentoring at [exercism](https://exercism.io/), i saw someone came up with a "[solution](https://exercism.io/mentor/solutions/11fa08eb00f843088c83531fed163ae6)" to complex-numbers that made absolutely no sense, but still passed all tests. I believe this was on purpose but he hasen't confirmed that yet. 

This is the code he uploaded:
```Prolog
real((X,_), X).

imaginary((_, Y), Y).

add((X, _), (Y, _), (Z, _)) :-
    nonvar(X), nonvar(Y), !,
    Z is X + Y.

add((X, _), (Y, _), (Z, _)) :-
    nonvar(Y), nonvar(Z), !,
    X is Z - Y.

add((X, _), (Y, _), (Z, _)) :-
    nonvar(X), nonvar(Z),
    Y is Z - X.

sub((X, _), (Y, _), (Z, _)) :-
    nonvar(Y), !,
    Y1 is -Y,
    add((X, _), (Y1, _), (Z, _)).

sub((X, _), (Y, _), (Z, _)) :-
    Y is X - Z.

mul((X, _), (Y, _), (Z, _)).

div((X, _), (Y, _), (Z, _)).

abs((X, _), 5).

conjugate((X, _), (Y, _)).
```

This passes the tests because they only check if the program recognize valid solutions for `add` `sub` ... etc. But not if its able to find those solutions. And in case of `abs`, because it only has tests with 5 as a result.

I believe I've fixed both cases. 