### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Prolog (short for "Programming Logic") is a [declarative](https://en.wikipedia.org/wiki/Declarative_programming) and logic
 based programming language developed in 1972 by Alain Colmerauer and Philippe Roussel. 
 It has many applications, most notably in Artificial Intelligence for its pattern matching abilities over natural language parse trees.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,4 +1,4 @@
-## Installation
+# Installation
 
 **Mac Users**: Install using homebrew with `brew install swi-prolog`. Alternatively, download the source for your machine from the [SWI Prolog Website](http://www.swi-prolog.org/download/devel) .
 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,4 +1,4 @@
-## References
+# References
 * [SWI-Prolog Getting Started](http://www.swi-prolog.org/pldoc/man?section=quickstart)
 * [SWISH - An online Prolog REPL](http://swish.swi-prolog.org/)
 * [Tutorials and Resources](http://www.swi-prolog.org/Links.html)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,4 +1,4 @@
-## Resources 
+# Resources 
 * [SWI Prolog Documentation](http://www.swi-prolog.org)
 * [SWISH - An online Prolog REPL](http://swish.swi-prolog.org/)
 * [Prolog on Stack Overflow](https://stackoverflow.com/tags/prolog)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,4 +1,4 @@
-## Running Tests
+# Running Tests
 
 SWI Prolog can either be run interactively or by executing it directly at the
 command line.

--- a/exercises/practice/satellite/.docs/instructions.append.md
+++ b/exercises/practice/satellite/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 Try using Prolog DCGs. **But watch out for left recursion!**
 
 For extra bonus points:


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
