### PR TITLE
Add icons for key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -227,32 +227,32 @@
     {
       "title": "Compatible",
       "content": "SWI-Prolog offers a comprehensive set of built-in predicates, covering many established standards.",
-      "icon": "TODO"
+      "icon": "interop"
     },
     {
       "title": "Simplicity",
       "content": "A single language element, called a clause, is the basis of all prolog relations and programs.",
-      "icon": "TODO"
+      "icon": "small"
     },
     {
       "title": "Declarative",
       "content": "Prolog focuses on what holds true about solutions, rather than how it is implemented.",
-      "icon": "TODO"
+      "icon": "multi-paradigm"
     },
     {
       "title": "Logical",
       "content": "Prolog is based on the rules of logic, with execution being a form of logical resolution.",
-      "icon": "TODO"
+      "icon": "scientific"
     },
     {
       "title": "Homoiconic",
       "content": "Prolog programs are also valid prolog terms, programs can interact with other prolog programs.",
-      "icon": "TODO"
+      "icon": "homoiconic"
     },
     {
       "title": "Portable",
       "content": "Implementations exist for Unix/Linux, Windows, MacOS platforms with targets to WebAssembly (WASM).",
-      "icon": "TODO"
+      "icon": "portable"
     }
   ],
   "tags": [


### PR DESCRIPTION
The icons for key features are now available, and `configlet lint` now requires that each key feature has a valid `icon` value.

This PR sets an initial icon for each key feature - feel free to change them however you want. You can see the list of available icons [here](https://github.com/exercism/docs/issues/189). Note that an icon can be used regardless of its name.

With the initial state of this PR, the key features look something like the below.

---

![interop](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/interop.svg) Compatible
SWI-Prolog offers a comprehensive set of built-in predicates, covering many established standards.

![small](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/small.svg) Simplicity
A single language element, called a clause, is the basis of all prolog relations and programs.

![multi-paradigm](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/multi-paradigm.svg) Declarative
Prolog focuses on what holds true about solutions, rather than how it is implemented.

![scientific](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/scientific.svg) Logical
Prolog is based on the rules of logic, with execution being a form of logical resolution.

![homoiconic](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/homoiconic.svg) Homoiconic
Prolog programs are also valid prolog terms, programs can interact with other prolog programs.

![portable](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/portable.svg) Portable
Implementations exist for Unix/Linux, Windows, MacOS platforms with targets to WebAssembly (WASM).
