### PR TITLE
complex-numbers: fix tests

### DIFF
--- a/exercises/practice/complex-numbers/complex_numbers_tests.plt
+++ b/exercises/practice/complex-numbers/complex_numbers_tests.plt
@@ -111,7 +111,7 @@ pending :-
 :- end_tests(absolute_value).
 
 
-:- begin_tests(conjugate).
+:- begin_tests(conjugate_value).
 
     test(conjugate_a_purely_real_number, condition(pending)) :-
         conjugate((5,0), (X,Y)), X =:= 5, Y =:= 0.
@@ -122,4 +122,4 @@ pending :-
     test(conjugate_a_number_with_real_and_imaginary_part, condition(pending)) :-
         conjugate((1,1), (X,Y)), X =:= 1, Y =:= -1.
 
-:- end_tests(conjugate).
+:- end_tests(conjugate_value).


### PR DESCRIPTION
The current tests failed with:

```
/2: Unknown procedure: plunit_conjugate:conjugate/2
  However, there are definitions for:
        conjugate/2
ERROR: /Users/erik/Code/exercism/solutions/prolog/complex-numbers/complex_numbers_tests.plt:122:
        test conjugate_a_number_with_real_and_imaginary_part: received error: plunit_conjugate:'unit body'/2: Unknown procedure: plunit_conjugate:conjugate/2
  However, there are definitions for:
        conjugate/2
```

This was due to the name of the tests begin/end (`conjugate`) matching the term that was tested (`conjugate`).