### PR TITLE
exercises: anagram: fix unicode warning. See #170

### DIFF
--- a/exercises/practice/anagram/anagram_tests.plt
+++ b/exercises/practice/anagram/anagram_tests.plt
@@ -1,3 +1,5 @@
+:- encoding(utf8).
+
 pending :-
     current_prolog_flag(argv, ['--all'|_]).
 pending :-


### PR DESCRIPTION
Fixes #170

Also see https://github.com/SWI-Prolog/swipl-devel/commit/821b605375773547d601f7e9e52b238e74858bd9
for similar PRs in swipl

Without this directive, you may get warnings when anagram is tested non-UTF8 environments.