### PR TITLE
Update instructions.md

### DIFF
--- a/exercises/practice/triangle/.docs/instructions.md
+++ b/exercises/practice/triangle/.docs/instructions.md
@@ -4,9 +4,7 @@ Determine if a triangle is equilateral, isosceles, or scalene.
 
 An _equilateral_ triangle has all three sides the same length.
 
-An _isosceles_ triangle has at least two sides the same length. (It is sometimes
-specified as having at least two sides the same length, but for the purposes of
-this exercise we'll say _exactly_ two.)
+An _isosceles_ triangle has at least two sides the same length. (Consider what this implies about other types of triangles.)
 
 A _scalene_ triangle has all sides of different lengths.
 


### PR DESCRIPTION
The instructions directly contradict the test suite. The definition states that an isosceles triangle has precisely two equal sides. This immediately excludes equilateral triangles. Yet the test suite specifically checks that an equilateral triangle is also classified as isosceles.