### PR TITLE
queen-attack: make X and Y different in diagonal attack/2 tests.

### DIFF
--- a/exercises/practice/queen-attack/queen_attack_tests.plt
+++ b/exercises/practice/queen-attack/queen_attack_tests.plt
@@ -48,15 +48,15 @@ pending :-
       attack((4,5), (2,5)).
 
     test(attack_first_diagonal, condition(pending)) :-
-      attack((2,2), (0,4)).
+      attack((2,3), (0,5)).
 
     test(attack_second_diagonal, condition(pending)) :-
-      attack((2,2), (3,1)).
+      attack((2,3), (3,2)).
 
     test(attack_third_diagonal, condition(pending)) :-
-      attack((2,2), (1,1)).
+      attack((2,3), (1,2)).
 
     test(attack_fourth_diagonal, condition(pending)) :-
-      attack((2,2), (5,5)).
+      attack((2,3), (5,6)).
 
 :- end_tests(attack_tests).


### PR DESCRIPTION
I have made an error in diagonal condition when doing queen-attack exercise. I wrote "abs(FromX-ToY)" instead of "abs(FromX-ToX)".

This was not catched by the tests, because the choises there are accidentally equial in this regard. Changing From tuple from (2,2) to (2,3) fixes this. I have adjusted To tuples accordingly.