### PR TITLE
Triangle - A bug or an extension?

### DIFF
--- a/exercises/practice/triangle/.docs/instructions.append.md
+++ b/exercises/practice/triangle/.docs/instructions.append.md
@@ -1,19 +1,6 @@
 # Instructions Append
 
-## Bonus: Type equality not enforced
+## Bonus: mixed types
 
-Tests don't validate if parameters aren't of the same ***type***.
-
-### Implication
-
-A solution with ***strict type equality*** would be **passing**.
-
-Implication of such a solution:
-```prolog
-?- triangle(1.0, 1, 1).
-false
-```
-
-### Resolution
-
-The above example would necessarily be ***true***, for a solution passing the bonus tests.
+If you're up for it, there are a couple of bonus tests where the types of the arguments are not all the same.
+These tests are optional, so you don't _have_ to solve before submitting your solution.

--- a/exercises/practice/triangle/.docs/instructions.append.md
+++ b/exercises/practice/triangle/.docs/instructions.append.md
@@ -1,0 +1,22 @@
+# Instructions Append
+
+## Type equality not enforced
+
+### Before
+
+Tests didn't test for the situation in which parameters weren't of the same ***type***.
+
+### Implication
+
+A solution with ***strict type equality*** would be **passing**.
+
+Example(of a solution enforcing type equality):
+```prolog
+?- triangle(1.0, 1, 1).
+false
+```
+
+### Currently
+
+A solution which doesn't enforce type equality is required.
+The above example would necessarily be ***true***, for a solution passing the tests.

--- a/exercises/practice/triangle/.docs/instructions.append.md
+++ b/exercises/practice/triangle/.docs/instructions.append.md
@@ -1,22 +1,19 @@
 # Instructions Append
 
-## Type equality not enforced
+## Bonus: Type equality not enforced
 
-### Before
-
-Tests didn't test for the situation in which parameters weren't of the same ***type***.
+Tests don't validate if parameters aren't of the same ***type***.
 
 ### Implication
 
 A solution with ***strict type equality*** would be **passing**.
 
-Example(of a solution enforcing type equality):
+Implication of such a solution:
 ```prolog
 ?- triangle(1.0, 1, 1).
 false
 ```
 
-### Currently
+### Resolution
 
-A solution which doesn't enforce type equality is required.
-The above example would necessarily be ***true***, for a solution passing the tests.
+The above example would necessarily be ***true***, for a solution passing the bonus tests.

--- a/exercises/practice/triangle/.meta/triangle.example.pl
+++ b/exercises/practice/triangle/.meta/triangle.example.pl
@@ -1,14 +1,15 @@
-triangle(Side, Side, Side, "equilateral") :-
-    valid_triangle(Side, Side, Side), !.
+triangle(Side1, Side2, Side3, "equilateral") :-
+      Side1 =:= Side2,
+      Side2 =:= Side3,
+      valid_triangle(Side1, Side2, Side3).
 
-triangle(SideEq, SideEq, OtherSide, "isosceles") :-
-    valid_triangle(SideEq, SideEq, OtherSide), !.
-
-triangle(SideEq, OtherSide, SideEq, "isosceles") :-
-    valid_triangle(SideEq, SideEq, OtherSide), !.
-
-triangle(OtherSide, SideEq, SideEq, "isosceles") :-
-    valid_triangle(SideEq, SideEq, OtherSide), !.
+triangle(Side1, Side2, Side3, "isosceles") :-
+    (
+	Side1 =:= Side2
+    ;	Side1 =:= Side3
+    ;	Side2 =:= Side3
+    ),
+    valid_triangle(Side1, Side2, Side3).
 
 triangle(Side1, Side2, Side3, "scalene") :-
     \+ triangle(Side1, Side2, Side3, "equilateral"),
@@ -25,3 +26,4 @@ valid_triangle(Side1, Side2, Side3) :-
     Side1 \== 0,
     Side2 \== 0,
     Side3 \== 0.
+

--- a/exercises/practice/triangle/triangle_tests.plt
+++ b/exercises/practice/triangle/triangle_tests.plt
@@ -21,6 +21,9 @@ pending :-
     test(all_sides_are_floats_and_equal, condition(pending)) :-
         triangle((0.5), (0.5), (0.5), "equilateral").
 
+    test(all_sides_are_equal_but_mixed_types, condition(true)) :-
+        triangle(2, 2.0, 2, "equilateral").
+
 :- end_tests(equilateral_triangle).
 
 :- begin_tests(isosceles_triangle).
@@ -51,6 +54,9 @@ pending :-
 
     test(sides_may_be_floats, condition(pending)) :-
         triangle((0.5), (0.4), (0.5), "isosceles").
+
+    test(sides_are_a_mix, condition(pending)) :-
+        triangle(5, 4, 5.0, "isosceles").
 
 :- end_tests(isosceles_triangle).
 

--- a/exercises/practice/triangle/triangle_tests.plt
+++ b/exercises/practice/triangle/triangle_tests.plt
@@ -4,87 +4,89 @@ pending :-
     write('\nA TEST IS PENDING!\n'),
     fail.
 
-bonus :-
-    current_prolog_flag(argv, ['--bonus'|_]).
-
-bonus :-
-    write('\nA TEST IS BONUS!\n'),
-    fail.
-
 :- begin_tests(equilateral_triangle).
 
-    test(all_sides_are_equal) :-
-        triangle(2, 2, 2, "equilateral").
+test(all_sides_are_equal) :-
+    triangle(2, 2, 2, "equilateral").
 
-    test(any_side_is_unequal, [fail, condition(pending)]) :-
-        triangle(2, 3, 2, "equilateral").
+test(any_side_is_unequal, [fail, condition(pending)]) :-
+    triangle(2, 3, 2, "equilateral").
 
-    test(no_sides_are_equal, [fail, condition(pending)]) :-
-        triangle(5, 4, 6, "equilateral").
+test(no_sides_are_equal, [fail, condition(pending)]) :-
+    triangle(5, 4, 6, "equilateral").
 
-    test(all_zero_sides_are_not_a_triangle, [fail, condition(pending)]) :-
-        triangle(0, 0, 0, "equilateral").
+test(all_zero_sides_are_not_a_triangle, [fail, condition(pending)]) :-
+    triangle(0, 0, 0, "equilateral").
 
-    test(all_sides_are_floats_and_equal, condition(pending)) :-
-        triangle((0.5), (0.5), (0.5), "equilateral").
-
-    test(all_sides_are_equal_but_mixed_types, condition(bonus)) :-
-        triangle(2, 2.0, 2, "equilateral").
+test(all_sides_are_floats_and_equal, condition(pending)) :-
+    triangle((0.5), (0.5), (0.5), "equilateral").
 
 :- end_tests(equilateral_triangle).
 
 :- begin_tests(isosceles_triangle).
 
-    test(last_two_sides_equal, condition(pending)) :-
-        triangle(3, 4, 4, "isosceles").
+test(last_two_sides_equal, condition(pending)) :-
+    triangle(3, 4, 4, "isosceles").
 
-    test(first_two_sides_equal, condition(pending)) :-
-        triangle(4, 4, 3, "isosceles").
+test(first_two_sides_equal, condition(pending)) :-
+    triangle(4, 4, 3, "isosceles").
 
-    test(first_and_last_sides_equal, condition(pending)) :-
-        triangle(4, 3, 4, "isosceles").
+test(first_and_last_sides_equal, condition(pending)) :-
+    triangle(4, 3, 4, "isosceles").
 
-    test(equilateral_triangles_are_also_isosceles, condition(pending)) :-
-        triangle(4, 4, 4, "isosceles").
+test(equilateral_triangles_are_also_isosceles, condition(pending)) :-
+    triangle(4, 4, 4, "isosceles").
 
-    test(no_sides_are_equal, [fail, condition(pending)]) :-
-        triangle(2, 3, 4, "isosceles").
+test(no_sides_are_equal, [fail, condition(pending)]) :-
+    triangle(2, 3, 4, "isosceles").
 
-    test(first_triangle_inequality_violation, [fail, condition(pending)]) :-
-        triangle(1, 1, 3, "isosceles").
+test(first_triangle_inequality_violation, [fail, condition(pending)]) :-
+    triangle(1, 1, 3, "isosceles").
 
-    test(second_triangle_inequality_violation, [fail, condition(pending)]) :-
-        triangle(1, 3, 1, "isosceles").
+test(second_triangle_inequality_violation, [fail, condition(pending)]) :-
+    triangle(1, 3, 1, "isosceles").
 
-    test(third_triangle_inequality_violation, [fail, condition(pending)]) :-
-        triangle(3, 1, 1, "isosceles").
+test(third_triangle_inequality_violation, [fail, condition(pending)]) :-
+    triangle(3, 1, 1, "isosceles").
 
-    test(sides_may_be_floats, condition(pending)) :-
-        triangle((0.5), (0.4), (0.5), "isosceles").
-
-    test(sides_are_a_mix, condition(bonus)) :-
-        triangle(5, 4, 5.0, "isosceles").
+test(sides_may_be_floats, condition(pending)) :-
+    triangle((0.5), (0.4), (0.5), "isosceles").
 
 :- end_tests(isosceles_triangle).
 
 :- begin_tests(scalene_triangle).
 
-    test(no_sides_are_equal, condition(pending)) :-
-        triangle(5, 4, 6, "scalene").
+test(no_sides_are_equal, condition(pending)) :-
+    triangle(5, 4, 6, "scalene").
 
-    test(no_sides_are_equal_mixed, condition(bonus)) :-
-        triangle(5.0, 4, 6, "scalene").
+test(all_sides_are_equal, [fail, condition(pending)]) :-
+    triangle(4, 4, 4, "scalene").
 
-    test(all_sides_are_equal, [fail, condition(pending)]) :-
-        triangle(4, 4, 4, "scalene").
+test(two_sides_are_equal, [fail, condition(pending)]) :-
+    triangle(4, 4, 3, "scalene").
 
-    test(two_sides_are_equal, [fail, condition(pending)]) :-
-        triangle(4, 4, 3, "scalene").
+test(may_not_violate_triangle_inequality, [fail, condition(pending)]) :-
+    triangle(7, 3, 2, "scalene").
 
-    test(may_not_violate_triangle_inequality, [fail, condition(pending)]) :-
-        triangle(7, 3, 2, "scalene").
-
-    test(small_scalene_triangle_with_floating_point_values, condition(pending)) :-
-        triangle((0.5), (0.4), (0.6), "scalene").
+test(small_scalene_triangle_with_floating_point_values, condition(pending)) :-
+    triangle((0.5), (0.4), (0.6), "scalene").
 
 :- end_tests(scalene_triangle).
+
+
+% BONUS TESTS
+bonus :-
+    current_prolog_flag(argv, ['--bonus'|_]).
+
+:- begin_tests(triangle_bonus, condition(bonus)).
+
+test(all_sides_are_equal_but_mixed_types) :-
+    triangle(2, 2.0, 2, "equilateral").
+
+test(sides_are_a_mix) :-
+    triangle(5, 4, 5.0, "isosceles").
+
+test(no_sides_are_equal_mixed) :-
+    triangle(5.0, 4, 6, "scalene").
+
+:- end_tests(triangle_bonus).

--- a/exercises/practice/triangle/triangle_tests.plt
+++ b/exercises/practice/triangle/triangle_tests.plt
@@ -7,10 +7,10 @@ pending :-
 :- begin_tests(equilateral_triangle).
 
     test(all_sides_are_equal) :-
-    	triangle(2, 2, 2, "equilateral").
+        triangle(2, 2, 2, "equilateral").
 
     test(any_side_is_unequal, [fail, condition(pending)]) :-
-    	triangle(2, 3, 2, "equilateral").
+        triangle(2, 3, 2, "equilateral").
 
     test(no_sides_are_equal, [fail, condition(pending)]) :-
         triangle(5, 4, 6, "equilateral").

--- a/exercises/practice/triangle/triangle_tests.plt
+++ b/exercises/practice/triangle/triangle_tests.plt
@@ -6,70 +6,70 @@ pending :-
 
 :- begin_tests(equilateral_triangle).
 
-test(all_sides_are_equal) :-
-    triangle(2, 2, 2, "equilateral").
+    test(all_sides_are_equal) :-
+    	triangle(2, 2, 2, "equilateral").
 
-test(any_side_is_unequal, [fail, condition(pending)]) :-
-    triangle(2, 3, 2, "equilateral").
+    test(any_side_is_unequal, [fail, condition(pending)]) :-
+    	triangle(2, 3, 2, "equilateral").
 
-test(no_sides_are_equal, [fail, condition(pending)]) :-
-    triangle(5, 4, 6, "equilateral").
+    test(no_sides_are_equal, [fail, condition(pending)]) :-
+        triangle(5, 4, 6, "equilateral").
 
-test(all_zero_sides_are_not_a_triangle, [fail, condition(pending)]) :-
-    triangle(0, 0, 0, "equilateral").
+    test(all_zero_sides_are_not_a_triangle, [fail, condition(pending)]) :-
+        triangle(0, 0, 0, "equilateral").
 
-test(all_sides_are_floats_and_equal, condition(pending)) :-
-    triangle((0.5), (0.5), (0.5), "equilateral").
+    test(all_sides_are_floats_and_equal, condition(pending)) :-
+        triangle((0.5), (0.5), (0.5), "equilateral").
 
 :- end_tests(equilateral_triangle).
 
 :- begin_tests(isosceles_triangle).
 
-test(last_two_sides_equal, condition(pending)) :-
-    triangle(3, 4, 4, "isosceles").
+    test(last_two_sides_equal, condition(pending)) :-
+        triangle(3, 4, 4, "isosceles").
 
-test(first_two_sides_equal, condition(pending)) :-
-    triangle(4, 4, 3, "isosceles").
+    test(first_two_sides_equal, condition(pending)) :-
+        triangle(4, 4, 3, "isosceles").
 
-test(first_and_last_sides_equal, condition(pending)) :-
-    triangle(4, 3, 4, "isosceles").
+    test(first_and_last_sides_equal, condition(pending)) :-
+        triangle(4, 3, 4, "isosceles").
 
-test(equilateral_triangles_are_also_isosceles, condition(pending)) :-
-    triangle(4, 4, 4, "isosceles").
+    test(equilateral_triangles_are_also_isosceles, condition(pending)) :-
+        triangle(4, 4, 4, "isosceles").
 
-test(no_sides_are_equal, [fail, condition(pending)]) :-
-    triangle(2, 3, 4, "isosceles").
+    test(no_sides_are_equal, [fail, condition(pending)]) :-
+        triangle(2, 3, 4, "isosceles").
 
-test(first_triangle_inequality_violation, [fail, condition(pending)]) :-
-    triangle(1, 1, 3, "isosceles").
+    test(first_triangle_inequality_violation, [fail, condition(pending)]) :-
+        triangle(1, 1, 3, "isosceles").
 
-test(second_triangle_inequality_violation, [fail, condition(pending)]) :-
-    triangle(1, 3, 1, "isosceles").
+    test(second_triangle_inequality_violation, [fail, condition(pending)]) :-
+        triangle(1, 3, 1, "isosceles").
 
-test(third_triangle_inequality_violation, [fail, condition(pending)]) :-
-    triangle(3, 1, 1, "isosceles").
+    test(third_triangle_inequality_violation, [fail, condition(pending)]) :-
+        triangle(3, 1, 1, "isosceles").
 
-test(sides_may_be_floats, condition(pending)) :-
-    triangle((0.5), (0.4), (0.5), "isosceles").
+    test(sides_may_be_floats, condition(pending)) :-
+        triangle((0.5), (0.4), (0.5), "isosceles").
 
-:- end_tests(isosceles_triangle).
+    :- end_tests(isosceles_triangle).
 
 :- begin_tests(scalene_triangle).
 
-test(no_sides_are_equal, condition(pending)) :-
-    triangle(5, 4, 6, "scalene").
+    test(no_sides_are_equal, condition(pending)) :-
+        triangle(5, 4, 6, "scalene").
 
-test(all_sides_are_equal, [fail, condition(pending)]) :-
-    triangle(4, 4, 4, "scalene").
+    test(all_sides_are_equal, [fail, condition(pending)]) :-
+        triangle(4, 4, 4, "scalene").
 
-test(two_sides_are_equal, [fail, condition(pending)]) :-
-    triangle(4, 4, 3, "scalene").
+    test(two_sides_are_equal, [fail, condition(pending)]) :-
+        triangle(4, 4, 3, "scalene").
 
-test(may_not_violate_triangle_inequality, [fail, condition(pending)]) :-
-    triangle(7, 3, 2, "scalene").
+    test(may_not_violate_triangle_inequality, [fail, condition(pending)]) :-
+        triangle(7, 3, 2, "scalene").
 
-test(small_scalene_triangle_with_floating_point_values, condition(pending)) :-
-    triangle((0.5), (0.4), (0.6), "scalene").
+    test(small_scalene_triangle_with_floating_point_values, condition(pending)) :-
+        triangle((0.5), (0.4), (0.6), "scalene").
 
 :- end_tests(scalene_triangle).
 
@@ -80,13 +80,13 @@ bonus :-
 
 :- begin_tests(triangle_bonus, [condition(bonus)]).
 
-test(all_sides_are_equal_but_mixed_types) :-
-    triangle(2, 2.0, 2, "equilateral").
+    test(all_sides_are_equal_but_mixed_types) :-
+        triangle(2, 2.0, 2, "equilateral").
 
-test(sides_are_a_mix) :-
-    triangle(5, 4, 5.0, "isosceles").
+    test(sides_are_a_mix) :-
+        triangle(5, 4, 5.0, "isosceles").
 
-test(no_sides_are_equal_mixed) :-
-    triangle(5.0, 4, 6, "scalene").
+    test(no_sides_are_equal_mixed) :-
+        triangle(5.0, 4, 6, "scalene").
 
 :- end_tests(triangle_bonus).

--- a/exercises/practice/triangle/triangle_tests.plt
+++ b/exercises/practice/triangle/triangle_tests.plt
@@ -4,9 +4,16 @@ pending :-
     write('\nA TEST IS PENDING!\n'),
     fail.
 
+bonus :-
+    current_prolog_flag(argv, ['--bonus'|_]).
+
+bonus :-
+    write('\nA TEST IS BONUS!\n'),
+    fail.
+
 :- begin_tests(equilateral_triangle).
 
-    test(all_sides_are_equal, condition(true)) :-
+    test(all_sides_are_equal) :-
         triangle(2, 2, 2, "equilateral").
 
     test(any_side_is_unequal, [fail, condition(pending)]) :-
@@ -21,7 +28,7 @@ pending :-
     test(all_sides_are_floats_and_equal, condition(pending)) :-
         triangle((0.5), (0.5), (0.5), "equilateral").
 
-    test(all_sides_are_equal_but_mixed_types, [condition(true), condition(bonus)]) :-
+    test(all_sides_are_equal_but_mixed_types, condition(bonus)) :-
         triangle(2, 2.0, 2, "equilateral").
 
 :- end_tests(equilateral_triangle).
@@ -55,7 +62,7 @@ pending :-
     test(sides_may_be_floats, condition(pending)) :-
         triangle((0.5), (0.4), (0.5), "isosceles").
 
-    test(sides_are_a_mix, [condition(pending), condition(bonus)]) :-
+    test(sides_are_a_mix, condition(bonus)) :-
         triangle(5, 4, 5.0, "isosceles").
 
 :- end_tests(isosceles_triangle).
@@ -65,7 +72,7 @@ pending :-
     test(no_sides_are_equal, condition(pending)) :-
         triangle(5, 4, 6, "scalene").
 
-    test(no_sides_are_equal_mixed, [condition(pending), condition(bonus)]) :-
+    test(no_sides_are_equal_mixed, condition(bonus)) :-
         triangle(5.0, 4, 6, "scalene").
 
     test(all_sides_are_equal, [fail, condition(pending)]) :-

--- a/exercises/practice/triangle/triangle_tests.plt
+++ b/exercises/practice/triangle/triangle_tests.plt
@@ -52,7 +52,7 @@ pending :-
     test(sides_may_be_floats, condition(pending)) :-
         triangle((0.5), (0.4), (0.5), "isosceles").
 
-    :- end_tests(isosceles_triangle).
+:- end_tests(isosceles_triangle).
 
 :- begin_tests(scalene_triangle).
 

--- a/exercises/practice/triangle/triangle_tests.plt
+++ b/exercises/practice/triangle/triangle_tests.plt
@@ -21,7 +21,7 @@ pending :-
     test(all_sides_are_floats_and_equal, condition(pending)) :-
         triangle((0.5), (0.5), (0.5), "equilateral").
 
-    test(all_sides_are_equal_but_mixed_types, condition(true)) :-
+    test(all_sides_are_equal_but_mixed_types, [condition(true), condition(bonus)]) :-
         triangle(2, 2.0, 2, "equilateral").
 
 :- end_tests(equilateral_triangle).
@@ -55,7 +55,7 @@ pending :-
     test(sides_may_be_floats, condition(pending)) :-
         triangle((0.5), (0.4), (0.5), "isosceles").
 
-    test(sides_are_a_mix, condition(pending)) :-
+    test(sides_are_a_mix, [condition(pending), condition(bonus)]) :-
         triangle(5, 4, 5.0, "isosceles").
 
 :- end_tests(isosceles_triangle).
@@ -64,6 +64,9 @@ pending :-
 
     test(no_sides_are_equal, condition(pending)) :-
         triangle(5, 4, 6, "scalene").
+
+    test(no_sides_are_equal_mixed, [condition(pending), condition(bonus)]) :-
+        triangle(5.0, 4, 6, "scalene").
 
     test(all_sides_are_equal, [fail, condition(pending)]) :-
         triangle(4, 4, 4, "scalene").

--- a/exercises/practice/triangle/triangle_tests.plt
+++ b/exercises/practice/triangle/triangle_tests.plt
@@ -78,7 +78,7 @@ test(small_scalene_triangle_with_floating_point_values, condition(pending)) :-
 bonus :-
     current_prolog_flag(argv, ['--bonus'|_]).
 
-:- begin_tests(triangle_bonus, condition(bonus)).
+:- begin_tests(triangle_bonus, [condition(bonus)]).
 
 test(all_sides_are_equal_but_mixed_types) :-
     triangle(2, 2.0, 2, "equilateral").


### PR DESCRIPTION
Hello there,

During a code review with bomber34, as I'm quite new to Prolog, he pointed out the following(from my solution):

```prolog
?- triangle(1.0, 1, 1).
false
```

This happens, because my solution which was similar to the example enforces type equality, and it shouldn't or should it?
I took the liberty to submit this patch, in case it's to be considered a bug.

Best regards,
cpmachado