### PR TITLE
hamming: update tests to use set-notation to avoid incorrect answers

### DIFF
--- a/exercises/practice/hamming/hamming_tests.plt
+++ b/exercises/practice/hamming/hamming_tests.plt
@@ -6,45 +6,44 @@ pending :-
 
 :- begin_tests(hamming).
 
-    test(identical_strands, condition(true)) :-
-        hamming_distance("A", "A", Result),
-            Result == 0.
+    test(identical_strands, [condition(true), set(Result == [0])]) :-
+        hamming_distance("A", "A", Result).
 
-    test(long_identical_strands, condition(pending)) :-
-        hamming_distance("GGACTGA", "GGACTGA", Result), Result == 0.
+    test(long_identical_strands, [condition(pending), set(Result == [0])]) :-
+        hamming_distance("GGACTGA", "GGACTGA", Result).
 
-    test(complete_distance_in_single_nucleotide_strands, condition(pending)) :-
-        hamming_distance("A", "G", 1).
+    test(complete_distance_in_single_nucleotide_strands, [condition(pending), set(Result == [1])]) :-
+        hamming_distance("A", "G", Result).
 
-    test(complete_distance_in_small_strands, condition(pending)) :-
-        hamming_distance("AG", "CT", Result), Result == 2.
+    test(complete_distance_in_small_strands, [condition(pending), set(Result == [2])]) :-
+        hamming_distance("AG", "CT", Result).
 
-    test(small_distance_in_small_strands, condition(pending)) :-
-        hamming_distance("AT", "CT", Result), Result == 1.
+    test(small_distance_in_small_strands, [condition(pending), set(Result == [1])]) :-
+        hamming_distance("AT", "CT", Result).
 
-    test(small_distance, condition(pending)) :-
-        hamming_distance("GGACG", "GGTCG", Result), Result == 1.
+    test(small_distance, [condition(pending), set(Result == [1])]) :-
+        hamming_distance("GGACG", "GGTCG", Result).
 
-    test(small_distance_in_long_strands, condition(pending)) :-
-        hamming_distance("ACCAGGG", "ACTATGG", Result), Result == 2.
+    test(small_distance_in_long_strands, [condition(pending), set(Result == [2])]) :-
+        hamming_distance("ACCAGGG", "ACTATGG", Result).
 
-    test(nonunique_character_in_first_strand, condition(pending)) :-
-        hamming_distance("AGA", "AGG", Result), Result == 1.
+    test(nonunique_character_in_first_strand, [condition(pending), set(Result == [1])]) :-
+        hamming_distance("AGA", "AGG", Result).
 
-    test(nonunique_character_in_second_strand, condition(pending)) :-
-        hamming_distance("AGG", "AGA", Result), Result == 1.
+    test(nonunique_character_in_second_strand, [condition(pending), set(Result == [1])]) :-
+        hamming_distance("AGG", "AGA", Result).
 
-    test(same_nucleotides_in_different_positions, condition(pending)) :-
-        hamming_distance("TAG", "GAT", Result), Result == 2.
+    test(same_nucleotides_in_different_positions, [condition(pending), set(Result == [2])]) :-
+        hamming_distance("TAG", "GAT", Result).
 
-    test(large_distance, condition(pending)) :-
-        hamming_distance("GATACA", "GCATAA", Result), Result == 4.
+    test(large_distance, [condition(pending), set(Result == [4])]) :-
+        hamming_distance("GATACA", "GCATAA", Result).
 
-    test(large_distance_in_offbyone_strand, condition(pending)) :-
-        hamming_distance("GGACGGATTCTG", "AGGACGGATTCT", Result), Result == 9.
+    test(large_distance_in_offbyone_strand, [condition(pending), set(Result == [9])]) :-
+        hamming_distance("GGACGGATTCTG", "AGGACGGATTCT", Result).
 
-    test(empty_strands, condition(pending)) :-
-        hamming_distance("", "", Result), Result == 0.
+    test(empty_strands, [condition(pending), set(Result == [0])]) :-
+        hamming_distance("", "", Result).
 
     test(disallow_first_strand_longer, [fail, condition(pending)]) :-
         hamming_distance("AATG", "AAA", _).


### PR DESCRIPTION
This PR aims to update the hamming exercise such that solutions that offer incorrect solutions among the correct answer is marked as false by the test process