### PR TITLE
fix: tests for saddle points

### DIFF
--- a/exercises/practice/atbash-cipher/atbash_cipher_tests.plt
+++ b/exercises/practice/atbash-cipher/atbash_cipher_tests.plt
@@ -35,7 +35,7 @@ pending :-
         Ciphertext == "gifgs rhurx grlm".
 
     test(encode_all_the_letters, condition(pending)) :-
-        encode("The quick brown fox jumps over the lazy dog." Ciphertext),
+        encode("The quick brown fox jumps over the lazy dog.", Ciphertext),
         Ciphertext == "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt".
 
     test(decode_exercism, condition(pending)) :-

--- a/exercises/practice/saddle-points/.meta/saddle_points.example.pl
+++ b/exercises/practice/saddle-points/.meta/saddle_points.example.pl
@@ -1,10 +1,10 @@
 :- use_module(library(clpfd)).
 
-saddle_point(Matrix, RowMaxes, ColMins, X, Y) :-
-    nth1(Y, Matrix, Row),
-    nth1(X, Row, Cell),
-    nth1(Y, RowMaxes, RowMax),
-    nth1(X, ColMins, ColMin),
+saddle_point(Matrix, RowMaxes, ColMins, R, C) :-
+    nth1(R, Matrix, Row),
+    nth1(C, Row, Cell),
+    nth1(R, RowMaxes, RowMax),
+    nth1(C, ColMins, ColMin),
     Cell #>= RowMax, Cell #=< ColMin.
 
 saddle_points(Matrix, SaddlePoints) :-
@@ -13,4 +13,9 @@ saddle_points(Matrix, SaddlePoints) :-
     maplist(min_list, Transposed, ColMins),
     length(RowMaxes, Rows),
     length(ColMins, Cols),
-    findall((X, Y), (between(1, Rows, Y), between(1, Cols, X), saddle_point(Matrix, RowMaxes, ColMins, X, Y)), SaddlePoints).
+    findall((R, C),
+            (
+                between(1, Rows, R),
+                between(1, Cols, C),
+                saddle_point(Matrix, RowMaxes, ColMins, R, C)),
+            SaddlePoints).

--- a/exercises/practice/saddle-points/saddle_points_tests.plt
+++ b/exercises/practice/saddle-points/saddle_points_tests.plt
@@ -10,7 +10,7 @@ pending :-
         Matrix = [[9, 8, 7], [5, 3, 2], [6, 6, 7]],
         saddle_points(Matrix, SaddlePoints),
         sort(SaddlePoints, SortedSaddlePoints),
-        SortedSaddlePoints == [(1, 2)].
+        SortedSaddlePoints == [(2, 1)].
 
     test(can_identify_that_empty_matrix_has_no_saddle_points, condition(pending)) :-
         Matrix = [],
@@ -26,13 +26,13 @@ pending :-
         Matrix = [[4, 5, 4], [3, 5, 5], [1, 5, 4]],
         saddle_points(Matrix, SaddlePoints),
         sort(SaddlePoints, SortedSaddlePoints),
-        SortedSaddlePoints == [(2, 1), (2, 2), (2, 3)].
+        SortedSaddlePoints == [(1, 2), (2, 2), (3, 2)].
 
     test(can_identify_multiple_saddle_points_in_a_row, condition(pending)) :-
         Matrix = [[6, 7, 8], [5, 5, 5], [7, 5, 6]],
         saddle_points(Matrix, SaddlePoints),
         sort(SaddlePoints, SortedSaddlePoints),
-        SortedSaddlePoints == [(1, 2), (2, 2), (3, 2)].
+        SortedSaddlePoints == [(2, 1), (2, 2), (2, 3)].
 
     test(can_identify_saddle_point_in_bottom_right_corner, condition(pending)) :-
         Matrix = [[8, 7, 9], [6, 7, 6], [3, 2, 5]],
@@ -43,18 +43,18 @@ pending :-
         Matrix = [[3, 1, 3], [3, 2, 4]],
         saddle_points(Matrix, SaddlePoints),
         sort(SaddlePoints, SortedSaddlePoints),
-        SortedSaddlePoints == [(1, 1), (3, 1)].
+        SortedSaddlePoints == [(1, 1), (1, 3)].
 
     test(can_identify_that_saddle_points_in_a_single_column_matrix_are_those_with_the_minimum_value, condition(pending)) :-
         Matrix = [[2], [1], [4], [1]],
         saddle_points(Matrix, SaddlePoints),
         sort(SaddlePoints, SortedSaddlePoints),
-        SortedSaddlePoints == [(1, 2), (1, 4)].
+        SortedSaddlePoints == [(2, 1), (4, 1)].
 
     test(can_identify_that_saddle_points_in_a_single_row_matrix_are_those_with_the_maximum_value, condition(pending)) :-
         Matrix = [[2, 5, 3, 5]],
         saddle_points(Matrix, SaddlePoints),
         sort(SaddlePoints, SortedSaddlePoints),
-        SortedSaddlePoints == [(2, 1), (4, 1)].
+        SortedSaddlePoints == [(1, 2), (1, 4)].
 
 :- end_tests(saddle_points).

--- a/exercises/practice/word-count/word_count_tests.plt
+++ b/exercises/practice/word-count/word_count_tests.plt
@@ -66,7 +66,7 @@ pending :-
           "don't"-2,
           "first"-1,
           "getting"-1,
-          "it"-1
+          "it"-1,
           "laugh"-1,
           "then"-1,
           "you're"-1


### PR DESCRIPTION
[EDITED] to change the test cases instead of the instruction

~~~~
The original instruction is confusing because it implies a row-first coordinate (row, col), 

> So the point at `[2, 1]` (row: 2, column: 1) is a great spot for a tree house.

but the expectation is a column-first coordinate, such as (col, row) or (X, Y) assuming X is on the horizontal axis. 

For example, the first test case is almost the same example as in the instruction, and it returns (1, 2) = (Col, Row).

The current instruction text `[2, 1]` is not consistent with the test result `(1, 2)`.

https://github.com/exercism/prolog/blob/64074e43cb2deae529ad60dd62afce73d23f8a00/exercises/practice/saddle-points/saddle_points_tests.plt#L10-L13