### PR TITLE
fix: improve error handling to catch syntax errors

### DIFF
--- a/bin/verify-exercises.sh
+++ b/bin/verify-exercises.sh
@@ -13,15 +13,19 @@ do
     exercise=$(basename "${example_file}" .example.pl)
     echo '-------------------------------------------------------'
     echo "Testing ${exercise}"
-    swipl -f  "${example_dir}/${exercise}.example.pl" -s "${exercise_dir}/${exercise}_tests.plt" -g run_tests,halt -t 'halt(1)' -- --all
-    if [ $? -ne 0 ]; then
+    if ! swipl -f "${example_file}" \
+               -s "${exercise_dir}/${exercise}_tests.plt" \
+               -g run_tests,halt \
+               -t 'halt(1)' \
+               --on-error=status \
+               -- --all; then
         TEST_RESULT=1
-        FAILED_EXERCISES+="${exercise}\n"
+        FAILED_EXERCISES+="${example_file}\n"
     fi
 done
 
 if [ "${TEST_RESULT}" -ne 0 ]; then
-    echo "The following exercises failed"
-    printf "${FAILED_EXERCISES}"
+    echo "The following exercises failed:"
+    printf "%b" "${FAILED_EXERCISES}"
     exit "${TEST_RESULT}"
 fi


### PR DESCRIPTION
- Updated `bin/verify-exercises.sh` to use `--on-error=status` for better error handling. The default behavior was to print a message and to return a success status.

Now, it catches a syntax error and shows the following output:

```shell
The following exercises failed:
exercises/practice/acronym/.meta/acronym.example.pl
```

Context
-------

I read this
- https://swi-prolog.discourse.group/t/automatic-tests-can-succeed-with-syntax-errors/3891/10

which leads to
- https://swi-prolog.discourse.group/t/changes-in-error-handling/3930

The above suggests that it can use `--on-error=status` to get the exit status of the program.