### PR TITLE
fix: argument name order mismatch with tests in rna_transcription.pl

### DIFF
--- a/exercises/practice/rna-transcription/rna_transcription.pl
+++ b/exercises/practice/rna-transcription/rna_transcription.pl
@@ -1,1 +1,1 @@
-rna_transcription(Rna, Dna).
+rna_transcription(Dna, Rna).


### PR DESCRIPTION
The following tests imply that the second argument is an RNA sequence, since only RNA has `U` base pairs. All the tests work if you just swap the initial order of the arguments, and implement the conversion correctly.

```prolog
    test(rna_complement_of_adenine_is_uracil, condition(pending)) :-
        rna_transcription("A", Result),
        Result == "U".

    test(rna_complement, condition(pending)) :-
        rna_transcription("ACGTGGTCTTAA", Result),
        Result == "UGCACCAGAAUU".
```